### PR TITLE
Add support for new P2SH testnet litecoin addresses

### DIFF
--- a/src/currencies.js
+++ b/src/currencies.js
@@ -13,7 +13,7 @@ var CURRENCIES = [{
 },{
     name: 'litecoin',
     symbol: 'ltc',
-    addressTypes: {prod: ['30', '05', '32'], testnet: ['6f', 'c4']}
+    addressTypes: {prod: ['30', '05', '32'], testnet: ['6f', 'c4', '3a']}
 },{
     name: 'peercoin',
     symbol: 'ppc',

--- a/test/wallet_address_validator.js
+++ b/test/wallet_address_validator.js
@@ -65,6 +65,7 @@ describe('WAValidator.validate()', function () {
             // p2sh addresses
             valid('3NJZLcZEEYBpxYEUGewU4knsQRn1WM5Fkt', 'litecoin');
             valid('2MxKEf2su6FGAUfCEAHreGFQvEYrfYNHvL7', 'litecoin', 'testnet');
+            valid('QW2SvwjaJU8LD6GSmtm1PHnBG2xPuxwZFy', 'litecoin', 'testnet');
         });
 
         it('should return true for correct peercoin addresses', function () {


### PR DESCRIPTION
According to https://github.com/litecoin-project/p2sh-convert/blob/master/index.html new P2SH litecoin addresses use a version value of 0x3a.